### PR TITLE
Add Future AGI

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ A flat CSV of every entry below — with categorization, stars, last-commit date
 | [OmniEvalKit](https://github.com/OpenBMB/OmniEvalKit) | Modular toolbox for evaluating LLMs and their omni-extensions across modalities, languages, and tasks. | ![](https://img.shields.io/github/stars/OpenBMB/OmniEvalKit?style=social) | ![](https://img.shields.io/github/last-commit/OpenBMB/OmniEvalKit) |
 | [promptfoo](https://github.com/promptfoo/promptfoo) | CLI and library for testing, evaluating, and red-teaming LLM apps — test-driven prompt engineering. | ![](https://img.shields.io/github/stars/promptfoo/promptfoo?style=social) | ![](https://img.shields.io/github/last-commit/promptfoo/promptfoo) |
 | [FastChat](https://github.com/lm-sys/FastChat) | Platform for training, serving, and evaluating LLMs — home of Chatbot Arena and MT-Bench. | ![](https://img.shields.io/github/stars/lm-sys/FastChat?style=social) | ![](https://img.shields.io/github/last-commit/lm-sys/FastChat) |
+| [Future AGI](https://github.com/future-agi/future-agi) | Open-source platform to **evaluate**, simulate, trace, guardrail, route, and optimize LLM and agent apps - 70+ eval metrics with LLM-as-judge. | ![](https://img.shields.io/github/stars/future-agi/future-agi?style=social) | ![](https://img.shields.io/github/last-commit/future-agi/future-agi) |
 
 ## Benchmarks
 


### PR DESCRIPTION
This PR adds Future AGI to this list in the Platforms And Software section.

Future AGI is an open-source (Apache-2.0), self-hostable platform for evaluating, tracing, and guardrailing LLM and AI agent apps, with 70+ eval metrics and LLM-as-judge.

The entry follows the list's existing format and placement conventions.

Disclosure: I'm affiliated with Future AGI.