### PR TITLE
Add Assevra (offline agent-reliability scorecard) to Platforms And Software

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ A flat CSV of every entry below — with categorization, stars, last-commit date
 | [OmniEvalKit](https://github.com/OpenBMB/OmniEvalKit) | Modular toolbox for evaluating LLMs and their omni-extensions across modalities, languages, and tasks. | ![](https://img.shields.io/github/stars/OpenBMB/OmniEvalKit?style=social) | ![](https://img.shields.io/github/last-commit/OpenBMB/OmniEvalKit) |
 | [promptfoo](https://github.com/promptfoo/promptfoo) | CLI and library for testing, evaluating, and red-teaming LLM apps — test-driven prompt engineering. | ![](https://img.shields.io/github/stars/promptfoo/promptfoo?style=social) | ![](https://img.shields.io/github/last-commit/promptfoo/promptfoo) |
 | [FastChat](https://github.com/lm-sys/FastChat) | Platform for training, serving, and evaluating LLMs — home of Chatbot Arena and MT-Bench. | ![](https://img.shields.io/github/stars/lm-sys/FastChat?style=social) | ![](https://img.shields.io/github/last-commit/lm-sys/FastChat) |
+| [Assevra](https://github.com/assevra/assevra) | Offline reliability scorecard for LLM agents — grounding, safety/refusal, PII-leak, and task-completion, each backed by a 95% confidence interval; emits a signed, portable scorecard with governance-framework mapping (EU AI Act / NIST AI RMF). | ![](https://img.shields.io/github/stars/assevra/assevra?style=social) | ![](https://img.shields.io/github/last-commit/assevra/assevra) |
 
 ## Benchmarks
 


### PR DESCRIPTION
Adds **Assevra** to the **Platforms And Software** table.

[Assevra](https://github.com/assevra/assevra) is an open-source (MIT) tool that turns *already-captured* LLM-agent outputs into a portable **reliability scorecard** — grounding/faithfulness, safety/refusal, PII-leak, and task-completion, each scored against a threshold with a **95% Wilson confidence interval**. It runs fully offline, emits a **signed** (Ed25519), self-contained scorecard you can commit to git or gate CI on, and maps results to governance frameworks (EU AI Act / NIST AI RMF / ISO 42001 / OWASP LLM Top 10). DOI: `10.5281/zenodo.21200852`.

It sits naturally alongside DeepEval / Inspect AI / Giskard OSS in this section — the emphasis is on producing a *portable, signed evidence artifact* rather than a dashboard.

Disclosure: I'm the author. Happy to reword, trim, or move it to **Grounding & Hallucination** / **Refusal & Safety** if you'd prefer a different placement.
