### PR TITLE
Add whatbroke to Agentic & Tool Use Evals

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ A flat CSV of every entry below — with categorization, stars, last-commit date
 | [ResearchHarness](https://github.com/black-yt/ResearchHarness) | Lightweight harness for tool-using LLM agents with fair benchmark evaluation and personal assistant workflows. | ![](https://img.shields.io/github/stars/black-yt/ResearchHarness?style=social) | ![](https://img.shields.io/github/last-commit/black-yt/ResearchHarness) |
 | [iris-eval mcp-server](https://github.com/iris-eval/mcp-server) | Agent eval standard for MCP — score output quality, catch safety failures, enforce cost budgets. | ![](https://img.shields.io/github/stars/iris-eval/mcp-server?style=social) | ![](https://img.shields.io/github/last-commit/iris-eval/mcp-server) |
 | [AIOpsLab](https://github.com/microsoft/AIOpsLab) | Microsoft holistic framework for designing, developing, and evaluating autonomous AIOps agents. | ![](https://img.shields.io/github/stars/microsoft/AIOpsLab?style=social) | ![](https://img.shields.io/github/last-commit/microsoft/AIOpsLab) |
+| [whatbroke](https://github.com/arthi-arumugam-git/whatbroke) | CLI that diffs agent behavior between two runs: dropped tool calls, drifted args, cost/latency regressions, outcome flips; multi-sample flap rates filter baseline noise. | ![](https://img.shields.io/github/stars/arthi-arumugam-git/whatbroke?style=social) | ![](https://img.shields.io/github/last-commit/arthi-arumugam-git/whatbroke) |
 
 ## Browser & Web Agent Evals
 


### PR DESCRIPTION
Adds whatbroke, an open-source CLI I built that diffs an AI agent's behavior between two recorded runs, for example before and after a model swap or prompt change. It reports dropped tool calls, drifted arguments, reordering, cost/latency regressions, and outcome flips, with multi-sample rates that demote behavior that was already flaky in the baseline. Deterministic and offline, no judge model or API keys, CI-gateable exit codes. MIT, TypeScript, on npm as whatbroke-cli.

Added to the Agentic & Tool Use Evals table in the existing badge format. Happy to move it to Platforms And Software if you think it fits better there.