### PR TITLE
Add StructEval benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ A flat CSV of every entry below — with categorization, stars, last-commit date
 | [article-extraction-benchmark](https://github.com/scrapinghub/article-extraction-benchmark) | Benchmark for article extraction libraries from Scrapinghub. | ![](https://img.shields.io/github/stars/scrapinghub/article-extraction-benchmark?style=social) | ![](https://img.shields.io/github/last-commit/scrapinghub/article-extraction-benchmark) |
 | [GameWorld](https://github.com/gameworld-project/gameworld) | Game-based benchmark environment for evaluating AI agents. | ![](https://img.shields.io/github/stars/gameworld-project/gameworld?style=social) | ![](https://img.shields.io/github/last-commit/gameworld-project/gameworld) |
 | [BIG-bench](https://github.com/google/BIG-bench) | Beyond the Imitation Game collaborative benchmark — 200+ tasks probing LLM capability and limitations. | ![](https://img.shields.io/github/stars/google/BIG-bench?style=social) | ![](https://img.shields.io/github/last-commit/google/BIG-bench) |
+| [StructEval](https://github.com/TIGER-AI-Lab/StructEval) | TMLR 2025 benchmark for structured-output generation and cross-format conversion, measuring syntax, structural fidelity, and visual fidelity across 18 text and renderable formats. | ![](https://img.shields.io/github/stars/TIGER-AI-Lab/StructEval?style=social) | ![](https://img.shields.io/github/last-commit/TIGER-AI-Lab/StructEval) |
 
 ## Agentic & Tool Use Evals
 


### PR DESCRIPTION
Adds StructEval to the Benchmarks table. StructEval is a TMLR 2025 benchmark for structured-output generation and cross-format conversion, evaluating syntax, structural fidelity, and visual fidelity across 18 text and renderable formats. The entry follows the repository’s existing table format and links the canonical implementation. Submitted by reacher-z (AI-assisted) for maintainer review.