### PR TITLE
Add Coder Eval to Coding Evals

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ A flat CSV of every entry below — with categorization, stars, last-commit date
 | Project | Description | Stars | Updated |
 |---|---|---|---|
 | [SWE-bench](https://github.com/SWE-bench/SWE-bench) | Benchmark for evaluating LLMs on real-world GitHub issue resolution. | ![](https://img.shields.io/github/stars/SWE-bench/SWE-bench?style=social) | ![](https://img.shields.io/github/last-commit/SWE-bench/SWE-bench) |
+| [Coder Eval](https://github.com/UiPath/coder_eval) | Sandboxed framework for evaluating coding agents and their skills with declarative YAML tasks, weighted scoring, and A/B experiments. | ![](https://img.shields.io/github/stars/UiPath/coder_eval?style=social) | ![](https://img.shields.io/github/last-commit/UiPath/coder_eval) |
 
 ## Multimodal Evals
 


### PR DESCRIPTION
Adds [Coder Eval](https://github.com/UiPath/coder_eval) to the **Coding Evals** section.

**What it is:** an open-source (Apache-2.0) framework for evaluating AI coding agents and their skills. It runs a real agent (Claude Code, Codex, or Gemini/Antigravity) in a sandbox against declarative YAML tasks, then scores the files and commands it actually produced.

**Why it fits the list's scope:**
- Open-source eval framework/harness, not a commercial platform with no open core ✅
- Agent and tool-use evaluation ✅
- Actively maintained — published to PyPI as [`coder-eval`](https://pypi.org/project/coder-eval/), currently 0.8.x

**How it differs from SWE-bench** (the section's only current entry): SWE-bench is a fixed dataset that ranks models on a shared leaderboard. Coder Eval is a harness for evaluating the tasks, skills, and workflows *you* ship — weighted 0.0–1.0 criteria across 14 criterion types, a `skill_triggered` activation check with suite-level precision/recall, an A/B experiment layer for comparing models or configs on identical tasks, and a GitHub Action for CI gating.

- Repo: https://github.com/UiPath/coder_eval
- Docs: https://coder-eval.com/docs
- PyPI: https://pypi.org/project/coder-eval/

**Note on generated files:** `data/repos.csv` is produced from `README.md` by `scripts/export_repos.py`, so I only touched `README.md` and left the CSV for the scheduled workflow to refresh.

Disclosure: I'm a maintainer of the project. Happy to reword the description or move the entry to a different section if you'd prefer.
