### PR TITLE
Add RepoTrials to Coding Evals

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ A flat CSV of every entry below — with categorization, stars, last-commit date
 | Project | Description | Stars | Updated |
 |---|---|---|---|
 | [SWE-bench](https://github.com/SWE-bench/SWE-bench) | Benchmark for evaluating LLMs on real-world GitHub issue resolution. | ![](https://img.shields.io/github/stars/SWE-bench/SWE-bench?style=social) | ![](https://img.shields.io/github/last-commit/SWE-bench/SWE-bench) |
+| [RepoTrials](https://github.com/PozziTiv4ik/Repo-Trials) | Local-first CLI that mines Git history into private coding-agent tasks, validates BASE/RED/GOLD transitions, compares repeated trials, and exports Harbor evaluations. | ![](https://img.shields.io/github/stars/PozziTiv4ik/Repo-Trials?style=social) | ![](https://img.shields.io/github/last-commit/PozziTiv4ik/Repo-Trials) |
 
 ## Multimodal Evals
 


### PR DESCRIPTION
## What

Adds [RepoTrials](https://github.com/PozziTiv4ik/Repo-Trials) to **Coding Evals**.

I maintain RepoTrials and am submitting it on behalf of the project. It is an Apache-2.0, local-first CLI that mines a repository's own Git history into private coding-agent evaluation tasks, validates BASE/RED/GOLD test transitions, compares repeated trials, and exports Harbor-compatible tasks.

## Verification

- First public release: [v0.1.0](https://github.com/PozziTiv4ik/Repo-Trials/releases/tag/v0.1.0)
- Reproducible no-key demo is documented at the top of the README
- Canonical project URL and both shields resolve
- README-only change; `git diff --check` passes

This is the project's first release; I am not claiming independent adoption or production maturity.