### PR TITLE
Add digline

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ A flat CSV of every entry below — with categorization, stars, last-commit date
 | [OmniEvalKit](https://github.com/OpenBMB/OmniEvalKit) | Modular toolbox for evaluating LLMs and their omni-extensions across modalities, languages, and tasks. | ![](https://img.shields.io/github/stars/OpenBMB/OmniEvalKit?style=social) | ![](https://img.shields.io/github/last-commit/OpenBMB/OmniEvalKit) |
 | [promptfoo](https://github.com/promptfoo/promptfoo) | CLI and library for testing, evaluating, and red-teaming LLM apps — test-driven prompt engineering. | ![](https://img.shields.io/github/stars/promptfoo/promptfoo?style=social) | ![](https://img.shields.io/github/last-commit/promptfoo/promptfoo) |
 | [FastChat](https://github.com/lm-sys/FastChat) | Platform for training, serving, and evaluating LLMs — home of Chatbot Arena and MT-Bench. | ![](https://img.shields.io/github/stars/lm-sys/FastChat?style=social) | ![](https://img.shields.io/github/last-commit/lm-sys/FastChat) |
+| [digline](https://github.com/digline/digline) | Regression testing for LLM apps — approved scores, prompt, and commit pinned as a versioned baseline in your repo. | ![](https://img.shields.io/github/stars/digline/digline?style=social) | ![](https://img.shields.io/github/last-commit/digline/digline) |
 
 ## Benchmarks
 


### PR DESCRIPTION
Adds digline to Platforms And Software: open-source regression testing for LLM apps, approved scores, prompt and commit pinned as a versioned baseline in the repo; digline compare reports which case got worse and by how much. On PyPI with provider plugins (Anthropic, OpenAI-compatible, Bedrock), docs at digline.dev, Apache-2.0.